### PR TITLE
Add support for RPi4 model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,5 +175,7 @@ jobs:
           # and the README.md
           sed -i -e 's/||VERSION||/'$CRATE_VERSION'/g' README.md
         
-      - name: Publish-Dry-Run
-        run: cargo make publish --env CRATES_TOKEN=${{ secrets.CRATES_TOKEN }} --profile pipeline
+      - name: Publish-Run
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        run: cargo make --profile pipeline publish 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     name: Compile The Crate
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [pi3, pi4_low, pi4_high]
 
     steps:
       # Checkout the current code from github into the CI machine
@@ -45,7 +48,9 @@ jobs:
           cat Cargo.toml
 
       - name: Compile
-        run: cargo make pi3 --profile pipeline
+        env:
+          FEATURES: ${{ matrix.platform }}
+        run: cargo make -t build --profile pipeline
 
   publish_dry:
     name: Run Cargo Publish Dry-Run
@@ -74,7 +79,7 @@ jobs:
           version: 'latest'
         
       - name: Publish-Dry-Run
-        run: cargo make publish_dry --profile pipeline
+        run: cargo make -t publish_dry --profile pipeline
 
   prepare_release:
     needs: [build, publish_dry]
@@ -178,4 +183,4 @@ jobs:
       - name: Publish-Run
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
-        run: cargo make --profile pipeline publish 
+        run: cargo make -t publish --profile pipeline 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## :cat: v0.6.0
+
+Introduce the MMIO address mapping to support also Raspberry 4 as a target for this crate.
+
+- ### :bulb: Features
+
+  - add features `pi4_low` and `pi4_high` to compile for Raspberry Pi 4 model
+
+- ### :wrench: Maintenance
+
+  - rename `ruspiro_pi3` feature to `pi3`
+
 ## :melon: v0.5.2
 
 This is a maintenance release ensuring successful build with the latest nightly (2021-09-05) version of Rust.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ruspiro-timer"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.5.2" # remember to update html_root_url
+version = "0.6.0" # remember to update html_root_url
 description = """This crates provides simple timing functions to pause the current processing for a specific amount of time. The core pausing is called on will block."""
-license = "Apache-2.0"
+license = "Apache-2.0 OR MIT"
 repository = "https://github.com/RusPiRo/ruspiro-timer/tree/v||VERSION||"
 documentation = "https://docs.rs/ruspiro-timer/||VERSION||"
 readme = "README.md"
@@ -19,13 +19,13 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 ruspiro-mmio-register = "~0.1.3"
 ruspiro-arch-aarch64 = "~0.1.5"
-ruspiro-interrupt = "~0.4.3"
+ruspiro-interrupt = "~0.5.0"
 ruspiro-singleton = "~0.4.3"
 
 [features]
 pi3 = ["ruspiro-interrupt/pi3"]
-pi4_lowperi = ["ruspiro-interrupt/pi4_lowperi"]
-pi4_highperi = ["ruspiro-interrupt/pi4_highperi"]
+pi4_low = ["ruspiro-interrupt/pi4_low"]
+pi4_high = ["ruspiro-interrupt/pi4_high"]
 
 [patch.crates-io]
 ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "development" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ ruspiro-interrupt = "~0.4.3"
 ruspiro-singleton = "~0.4.3"
 
 [features]
-ruspiro_pi3 = ["ruspiro-interrupt/ruspiro_pi3"]
+pi3 = ["ruspiro-interrupt/pi3"]
+pi4_lowperi = ["ruspiro-interrupt/pi4_lowperi"]
+pi4_highperi = ["ruspiro-interrupt/pi4_highperi"]
 
 [patch.crates-io]
 ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "development" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,7 +10,7 @@ CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune
 RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
 
 # AARCH64 specific Travis CI env. variables. "aarch64-none-elf" is not available there as it seems
-[env.travis]
+[env.pipeline]
 CC = "aarch64-linux-gnu-gcc"
 AR = "aarch64-linux-gnu-ar"
 CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
@@ -29,14 +29,6 @@ args = ["clippy", "--features", "${FEATURES}"]
 env = { FEATURES = "pi3" }
 command = "cargo"
 args = ["doc", "--features", "${FEATURES}", "--open"]
-
-[tasks.pi3]
-env = { FEATURES = "pi3" }
-run_task = "build"
-
-[tasks.pi4]
-env = { FEATURES = "pi4_lowperi" }
-run_task = "build"
 
 [tasks.clean]
 command = "cargo"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,17 +21,21 @@ command = "cargo"
 args = ["build", "--release", "--features", "${FEATURES}"]
 
 [tasks.clippy]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "pi3" }
 command = "cargo"
 args = ["clippy", "--features", "${FEATURES}"]
 
 [tasks.doc]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "pi3" }
 command = "cargo"
 args = ["doc", "--features", "${FEATURES}", "--open"]
 
 [tasks.pi3]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "pi3" }
+run_task = "build"
+
+[tasks.pi4]
+env = { FEATURES = "pi4_lowperi" }
 run_task = "build"
 
 [tasks.clean]
@@ -39,11 +43,11 @@ command = "cargo"
 args = ["clean"]
 
 [tasks.publish_dry]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "pi3" }
 command = "cargo"
 args = ["publish", "--dry-run", "--features", "${FEATURES}"]
 
 [tasks.publish]
-env = { FEATURES = "ruspiro_pi3" }
+env = { FEATURES = "pi3" }
 command = "cargo"
 args = ["publish", "--token", "${CRATES_TOKEN}", "--allow-dirty", "--features", "${FEATURES}"]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ free-running counter of the Raspberry Pi to provide micro second accurate pause 
 
 ## Features
 
-Feature         | Description
-----------------|------------------------------------------------------------------------------
-``ruspiro_pi3`` | active to use the proper timer MMIO base memory address for Raspberry Pi 3 when accessing the system timer peripheral
+Feature    | Description
+-----------|------------------------------------------------------------------------------
+`pi3`      | active to use the proper timer MMIO base memory address for Raspberry Pi 3 when accessing the system timer peripheral
+`pi4_low`  | active to use the proper timer MMIO base memory address for Raspberry Pi 4 in Low-Peripheral mode when accessing the system timer peripheral
+`pi4_high` | active to use the proper timer MMIO base memory address for Raspberry Pi 4 in High-Peripheral mode when accessing the system timer peripheral
 
 ## Usage
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -13,9 +13,9 @@ use ruspiro_mmio_register::define_mmio_register;
 // MMIO peripheral base address based on the target family provided with the custom target config file.
 #[cfg(feature = "pi3")]
 const PERIPHERAL_BASE: usize = 0x0_3F00_0000;
-#[cfg(feature = "pi4_lowperi")]
+#[cfg(feature = "pi4_low")]
 const PERIPHERAL_BASE: usize = 0x0_FE00_0000;
-#[cfg(feature = "pi4_highperi")]
+#[cfg(feature = "pi4_high")]
 const PERIPHERAL_BASE: usize = 0x4_7E00_0000;
 
 // Base address of system timer MMIO register

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -11,8 +11,12 @@
 use ruspiro_mmio_register::define_mmio_register;
 
 // MMIO peripheral base address based on the target family provided with the custom target config file.
-#[cfg(feature = "ruspiro_pi3")]
-const PERIPHERAL_BASE: usize = 0x3F00_0000;
+#[cfg(feature = "pi3")]
+const PERIPHERAL_BASE: usize = 0x0_3F00_0000;
+#[cfg(feature = "pi4_lowperi")]
+const PERIPHERAL_BASE: usize = 0x0_FE00_0000;
+#[cfg(feature = "pi4_highperi")]
+const PERIPHERAL_BASE: usize = 0x4_7E00_0000;
 
 // Base address of system timer MMIO register
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@
 //! `ruspiro_pi3` | active to use the proper timer MMIO base memory address for Raspberry Pi 3 when accessing the system timer peripheral
 //!
 
+#[cfg(not(any(feature = "pi3", feature = "pi4_lowperi", feature = "pi4_highperi")))]
+compile_error!("Either feature \"pi3\", \"pi4_lowperi\" or \"pi4_highperi\" must be enabled for this crate");
+
 extern crate alloc;
 
 mod interface;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
 //! `ruspiro_pi3` | active to use the proper timer MMIO base memory address for Raspberry Pi 3 when accessing the system timer peripheral
 //!
 
-#[cfg(not(any(feature = "pi3", feature = "pi4_lowperi", feature = "pi4_highperi")))]
-compile_error!("Either feature \"pi3\", \"pi4_lowperi\" or \"pi4_highperi\" must be enabled for this crate");
+#[cfg(not(any(feature = "pi3", feature = "pi4_low", feature = "pi4_high")))]
+compile_error!("Either feature \"pi3\", \"pi4_low\" or \"pi4_high\" must be enabled for this crate");
 
 extern crate alloc;
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -166,7 +166,7 @@ pub fn schedule<F: FnOnce() + 'static + Send>(delay: Duration, function: F) {
 
 /// Implement the timer interrupt handler for interrupt based timed execution
 #[IrqHandler(SystemTimer1)]
-unsafe fn timer_handler(tx: Option<IsrSender<Box<dyn Any>>>) {
+unsafe fn timer_handler(channel: Option<IsrSender<Box<dyn Any>>>) {
   // check which timer compare/match value has raised this interrupt, only care on number 1 ...
   if SYS_TIMERCS::Register.read(SYS_TIMERCS::M1) == 1 {
     // first acknowledge the timer interrupt by writing 1 to the match register value


### PR DESCRIPTION
Add Raspberry Pi4 4 support to the crate.
This adds 2 features for the RPi4 to ensure it could use MMIO address range either in low-peri or high-peri mode.